### PR TITLE
Fix Clientside tables

### DIFF
--- a/src/components/PasswordTable.vue
+++ b/src/components/PasswordTable.vue
@@ -55,7 +55,6 @@ export default {
       hasLoaded: false,
       columns: ['hash', 'value', 'cracked_at'],
       options: {
-        skin: 'table-bordered table-hover passwords',
         sortIcon: {base: 'fa', up: 'fa-sort-asc', down: 'fa-sort-desc'},
         orderBy: {
           column: 'cracked_at',

--- a/src/main.js
+++ b/src/main.js
@@ -28,8 +28,8 @@ Vue.config.productionTip = false
 window.axios = axios
 
 Vue.use(Vuelidate)
-Vue.use(ClientTable)
-Vue.use(ServerTable, {}, false)
+Vue.use(ClientTable, {}, false, 'bootstrap4')
+Vue.use(ServerTable, {}, false, 'bootstrap4')
 Vue.use(BootstrapVue)
 
 // Sync vue's router with the state backend

--- a/src/views/TaskStatus.vue
+++ b/src/views/TaskStatus.vue
@@ -224,7 +224,6 @@ export default {
         loaded: false,
         columns: ['occurred_at', 'user_id', 'status_code', 'type'],
         options: {
-          skin: 'table-bordered table-hover passwords',
           sortIcon: {base: 'fa', up: 'fa-sort-asc', down: 'fa-sort-desc'}
         }
       }


### PR DESCRIPTION
I should read the changes more often... vue-tables-2 update introduced a new `theme` option. The tables for showing cracked passwords and the audit log were broken due to wrong styles being applied.