### PR TITLE
Added support for Sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,16 @@
     "url": "https://github.com/fireeye/gocrack-ui"
   },
   "scripts": {
-    "serve": "vue-cli-service serve",
-    "build": "export APP_VERSION=$(git rev-parse HEAD) && vue-cli-service build",
+    "serve": "export VUE_APP_VERSION=$(git rev-parse HEAD) && vue-cli-service serve",
+    "build": "export VUE_APP_VERSION=$(git rev-parse HEAD) && vue-cli-service build",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^1.2.19",
     "@fortawesome/free-solid-svg-icons": "^5.9.0",
     "@fortawesome/vue-fontawesome": "^0.1.6",
+    "@sentry/browser": "^5.4.0",
+    "@sentry/integrations": "^5.4.1",
     "axios": "^0.19.0",
     "bootstrap-vue": "^2.0.0-rc.22",
     "chart.js": "^2.8.0",

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,9 @@
 /* eslint-env node */
 
-export const APP_VERSION = process.env.APP_VERSION
+export const APP_VERSION = process.env.VUE_APP_VERSION
+export const SENTRY_DSN = process.env.VUE_APP_GOCRACK_SENTRY_DSN
 
 export default {
-  APP_VERSION
+  APP_VERSION,
+  SENTRY_DSN
 }

--- a/src/main.js
+++ b/src/main.js
@@ -11,18 +11,29 @@ import axios from 'axios'
 import Vuelidate from 'vuelidate'
 import BootstrapVue from 'bootstrap-vue'
 import VuePlugin from '@/api'
+import * as Sentry from '@sentry/browser'
+import * as Integrations from '@sentry/integrations'
 
 import '@/faloader'
+import config from '@/config'
 
 import 'popper.js/dist/umd/popper.min.js'
 import 'bootstrap/dist/js/bootstrap.min.js'
-
 import 'vue-multiselect/dist/vue-multiselect.min.css'
 
 // Custom Components
 import * as CreateTaskComponents from './components/CreateTask'
 
 import * as HashcatComponents from './components/Hashcat'
+
+if (config.SENTRY_DSN !== '') {
+  console.log('Sentry enabled')
+
+  Sentry.init({
+    dsn: 'https://<key>@sentry.io/<project>',
+    integrations: [new Integrations.Vue({ Vue, attachProps: true })]
+  })
+}
 
 const tableIcons = {
   base: 'fa fas',

--- a/src/views/VersionInfo.vue
+++ b/src/views/VersionInfo.vue
@@ -68,7 +68,7 @@ export default {
 
   methods: {
     getGithubUrl (isUI = false) {
-      let ver = isUI ? this.ui_version : this.data.version
+      let ver = isUI ? this.getAppVersion : this.data.version
       let rev = (this.data !== null ? ver : 'master')
       return isUI ? `https://github.com/fireeye/gocrack-ui/tree/${rev}` : `https://github.com/fireeye/gocrack/tree/${rev}`
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -753,6 +753,67 @@
     consola "^2.3.0"
     node-fetch "^2.3.0"
 
+"@sentry/browser@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.4.0.tgz#4c553e4769555e09a34f8f86c6af27ebec74c715"
+  integrity sha512-lsGJqryHXrnWRkdahnep0m+m65zyMJGCmB2T8pGS+SFcSXdx94TaK4PiPaCl6XUCT5ejuQUHoXsEBmK/3S6beA==
+  dependencies:
+    "@sentry/core" "5.4.0"
+    "@sentry/types" "5.4.0"
+    "@sentry/utils" "5.4.0"
+    tslib "^1.9.3"
+
+"@sentry/core@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.4.0.tgz#c40969ace80d637195bcc0ae6e5819f0c5e8ae46"
+  integrity sha512-luIJPftVnrW0ZKqs9W6YCpzKZVbOgQv8Ae7KB0Acsvqeoqjtx4zHHfVfu5VPkfhrOYN3NsM1IpApXtSdMiJCfg==
+  dependencies:
+    "@sentry/hub" "5.4.0"
+    "@sentry/minimal" "5.4.0"
+    "@sentry/types" "5.4.0"
+    "@sentry/utils" "5.4.0"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.4.0.tgz#03ab154bf2e2c33cb80d951b464de84ad2a6fbf9"
+  integrity sha512-X0iLNcouXcLWzuOJz2YjTn1E11b7pzcG98/iFTHW3AKPjnJNt92XRpjsDI2iT8+ODUDiFqaFmACSn2oZK80WGQ==
+  dependencies:
+    "@sentry/types" "5.4.0"
+    "@sentry/utils" "5.4.0"
+    tslib "^1.9.3"
+
+"@sentry/integrations@^5.4.1":
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-5.4.1.tgz#c88a010d3eb8b73c45bc535d322cb168f79c57ef"
+  integrity sha512-969+4ZK2mTbBnNkonVIlj6b/jUdvo69qxDquUEl/6mBZJ5iOh43wOtlBm7FpzSQ3vAfHhFGv226QHEsacmKypw==
+  dependencies:
+    "@sentry/types" "5.4.0"
+    "@sentry/utils" "5.4.0"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.4.0.tgz#e3c569c68d6c09aad533832b2c713ad94bb2a511"
+  integrity sha512-MuOLavHHTXXWKyfTcwqpjhkdYlJDyOfjfcf+b/d38+8cs064rpNScxTZyYj2KKxNGcCqDgUsY175fNp/D1fyMw==
+  dependencies:
+    "@sentry/hub" "5.4.0"
+    "@sentry/types" "5.4.0"
+    tslib "^1.9.3"
+
+"@sentry/types@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.4.0.tgz#340854be18618e4435f9c168adfa2c9e407fbcb3"
+  integrity sha512-R8IFM77rzp0ngR/XQFLsXUK2uE7jLf21MsU9mpUwLtxcJp8rs7I77HgzA5MEerdG9Sbxw5RaLq9wO7noHGfUmQ==
+
+"@sentry/utils@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.4.0.tgz#32882f16cd516f341ba1dafeb020614aaf6d4b5c"
+  integrity sha512-NlYMAyiI9iIItLDxJ17tLMtuu7261t93tcOGSMdDQZlmryR6ZAMenbCKTf5MrpA2iHfX84gyfmr67lh8uSHkPg==
+  dependencies:
+    "@sentry/types" "5.4.0"
+    tslib "^1.9.3"
+
 "@soda/friendly-errors-webpack-plugin@^1.7.1":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@soda/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.1.tgz#706f64bcb4a8b9642b48ae3ace444c70334d615d"
@@ -8655,7 +8716,7 @@ tryer@^1.0.0:
   resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
 
-tslib@^1.9.0:
+tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
If you want Sentry enabled for the UI, you may do so by setting the environment variable `VUE_APP_GOCRACK_SENTRY_DSN` with the value of your given Sentry DSN