### PR TITLE
Added default time limit of 48 hours to tasks

### DIFF
--- a/src/components/CreateTask/TimeLimitInput.vue
+++ b/src/components/CreateTask/TimeLimitInput.vue
@@ -19,6 +19,11 @@
 import { chCompValidator } from '@/mixins'
 
 export default {
-  mixins: [chCompValidator]
+  mixins: [chCompValidator],
+  data () {
+    return {
+      text: '172,800'
+    }
+  }
 }
 </script>

--- a/src/i18n/en-US.json
+++ b/src/i18n/en-US.json
@@ -76,7 +76,7 @@
         "description_users": "Users that will receive emails when passwords crack and who will have access to this task via this web interface.",
         "description_priority": "Relative priority of this task. Used to allocate GPUs and to prioritize tasks on the queue when necessary. If using a Higher priority, you may want to indicate why in the comment field.",
         "taskTimeLimit": "Runtime Limit",
-        "taskTimeLimit_description": "The total runtime in seconds this job is allowed to run before it is automatically stopped",
+        "taskTimeLimit_description": "The total runtime in seconds this job is allowed to run before it is automatically stopped. (default is 172,800 seconds, or 48 hours)",
         "error_taskTimeLimit": "The time limit must be expressed as an integer (in seconds)",
         "error_casecode": "The Case Code is required and must be at least 4 characters",
         "error_taskname": "The Task Name is required and must be at least 10 characters",


### PR DESCRIPTION
Added default of 172,800 seconds to task creation. Most tasks _probably_ don't need to go past two days time.

This could probably be improved to a dropdown of preset values, and then allowing for a custom value as well. Maybe in a future PR. 👍 