### PR TITLE
Reversed register and login buttons on the login page

### DIFF
--- a/assets/scss/_login.scss
+++ b/assets/scss/_login.scss
@@ -39,7 +39,7 @@
 }
 
 form.form-signin a {
-  margin-bottom: 5px;
+  margin: 5px 0px;
 }
 
 form.form-signin a:hover, a:focus { 

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -4,10 +4,10 @@
       <h2 class="form-signin-heading">{{ $t('login.header') }}</h2>
       <input type="username" id="inputUsername" class="form-control" :placeholder="$t('login.placeholder_username')" v-model="credentials.username" autofocus>
       <input type="password" id="inputPassword" class="form-control" :placeholder="$t('login.placeholder_password')" v-model="credentials.password">
+      <button class="btn btn-lg btn-primary btn-block" :disabled="isAuthPending" @click="submit()">{{ $t('login.button_login') }}</button>
       <router-link to="/register" exact>
         <a href="#" class="btn btn-success btn-lg btn-block" role="button" aria-pressed="true" v-if="canUserRegister">{{ $t('login.register') }}</a>
       </router-link>
-      <button class="btn btn-lg btn-primary btn-block" :disabled="isAuthPending" @click="submit()">{{ $t('login.button_login') }}</button>
     </form>
   </div>
 </template>


### PR DESCRIPTION
9 times out of 10, the login button comes before the register button on a login form. There's been plenty of times that I hit "register" opposed to "login". This just switches it around, better UX.